### PR TITLE
한 멤버가 갖고 있는 Project 관련 정보 리스트 조회 기능

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,19 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to author to set pr creator as assignee
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - ashlovesliitea
+  - rilac1
+
+  # A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - wip
+  - skip-review
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0

--- a/src/main/java/yapp/allround3/common/security/Secret.java
+++ b/src/main/java/yapp/allround3/common/security/Secret.java
@@ -1,0 +1,6 @@
+package yapp.allround3.common.security;
+
+public class Secret {
+    //TODO: 추후에 AWS SecretsManager등 도입 고려해볼 것.
+    public static final String secretKey = "9y$B&E)H@McQeThW";
+}

--- a/src/main/java/yapp/allround3/common/security/SecurityUtils.java
+++ b/src/main/java/yapp/allround3/common/security/SecurityUtils.java
@@ -1,0 +1,44 @@
+package yapp.allround3.common.security;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.Base64Utils;
+import yapp.allround3.common.exception.CustomException;
+
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.spec.AlgorithmParameterSpec;
+
+@RequiredArgsConstructor
+public class SecurityUtils {
+    public static String encodeKey(Long id){
+
+        try {
+            byte[] textBytes = id.toString().getBytes("UTF-8");
+            AlgorithmParameterSpec ivSpec = new IvParameterSpec(Secret.secretKey.getBytes());
+            SecretKeySpec newKey = new SecretKeySpec(Secret.secretKey.getBytes("UTF-8"), "AES");
+            Cipher cipher = null;
+                    cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            cipher.init(Cipher.ENCRYPT_MODE, newKey, ivSpec);
+            return Base64Utils.encodeToString(cipher.doFinal(textBytes));
+        } catch (Exception e) {
+            throw new CustomException(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public static String decodeKey(String encodedKey){
+        try {
+            AlgorithmParameterSpec ivSpec = new IvParameterSpec(Secret.secretKey.getBytes());
+            SecretKeySpec newKey = new SecretKeySpec(Secret.secretKey.getBytes("UTF-8"), "AES");
+            byte[] textBytes = Base64.decodeBase64(encodedKey);
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            cipher.init(Cipher.DECRYPT_MODE, newKey, ivSpec);
+            return new String(cipher.doFinal(textBytes), "UTF-8");
+        }catch (Exception e){
+            throw new CustomException(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/yapp/allround3/common/security/SecurityUtils.java
+++ b/src/main/java/yapp/allround3/common/security/SecurityUtils.java
@@ -29,14 +29,14 @@ public class SecurityUtils {
         }
     }
 
-    public static String decodeKey(String encodedKey){
+    public static Long decodeKey(String encodedKey){
         try {
             AlgorithmParameterSpec ivSpec = new IvParameterSpec(Secret.secretKey.getBytes());
             SecretKeySpec newKey = new SecretKeySpec(Secret.secretKey.getBytes("UTF-8"), "AES");
             byte[] textBytes = Base64.decodeBase64(encodedKey);
             Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
             cipher.init(Cipher.DECRYPT_MODE, newKey, ivSpec);
-            return new String(cipher.doFinal(textBytes), "UTF-8");
+            return Long.valueOf(new String(cipher.doFinal(textBytes), "UTF-8"));
         }catch (Exception e){
             throw new CustomException(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/yapp/allround3/feedback/domain/Template.java
+++ b/src/main/java/yapp/allround3/feedback/domain/Template.java
@@ -18,7 +18,7 @@ public class Template {
 
     private String contents;
 
-    public static Template createTemplate(String contents){
+    public static Template from(String contents){
         Template template=new Template();
         template.contents=contents;
         return template;

--- a/src/main/java/yapp/allround3/participant/controller/dto/ParticipantDto.java
+++ b/src/main/java/yapp/allround3/participant/controller/dto/ParticipantDto.java
@@ -1,0 +1,17 @@
+package yapp.allround3.participant.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import yapp.allround3.participant.domain.Participant;
+
+@Data
+@AllArgsConstructor
+public class ParticipantDto {
+    private String name;
+    private String imageUrl;
+
+    public static ParticipantDto of(Participant participant) {
+        return new ParticipantDto(participant.getMember().getName(),
+                participant.getMember().getImageUrl());
+    }
+}

--- a/src/main/java/yapp/allround3/participant/controller/dto/ParticipantDto.java
+++ b/src/main/java/yapp/allround3/participant/controller/dto/ParticipantDto.java
@@ -2,16 +2,19 @@ package yapp.allround3.participant.controller.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import yapp.allround3.participant.domain.Participant;
 
 @Data
-@AllArgsConstructor
+@NoArgsConstructor
 public class ParticipantDto {
     private String name;
     private String imageUrl;
 
     public static ParticipantDto of(Participant participant) {
-        return new ParticipantDto(participant.getMember().getName(),
-                participant.getMember().getImageUrl());
+        ParticipantDto participantDto = new ParticipantDto();
+        participantDto.setName(participant.getMember().getName());
+        participantDto.setImageUrl(participant.getMember().getImageUrl());
+        return participantDto;
     }
 }

--- a/src/main/java/yapp/allround3/participant/domain/Participant.java
+++ b/src/main/java/yapp/allround3/participant/domain/Participant.java
@@ -31,7 +31,7 @@ public class Participant {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	public static Participant createParticipant(Project project,Member member){
+	public static Participant from(Project project,Member member){
 		Participant participant=new Participant();
 		participant.member=member;
 		participant.project=project;

--- a/src/main/java/yapp/allround3/participant/domain/Participant.java
+++ b/src/main/java/yapp/allround3/participant/domain/Participant.java
@@ -30,4 +30,11 @@ public class Participant {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
+
+	public static Participant createParticipant(Project project,Member member){
+		Participant participant=new Participant();
+		participant.member=member;
+		participant.project=project;
+		return participant;
+	}
 }

--- a/src/main/java/yapp/allround3/participant/repository/ParticipantRepository.java
+++ b/src/main/java/yapp/allround3/participant/repository/ParticipantRepository.java
@@ -4,10 +4,14 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.jpa.repository.Query;
 import yapp.allround3.member.domain.Member;
 import yapp.allround3.participant.domain.Participant;
+import yapp.allround3.project.domain.Project;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
-
 	List<Participant> findByMember(Member member);
+
+	@Query("select p from Participant p join fetch p.member")
+	List<Participant> findParticipantsByProject(Project project);
 }

--- a/src/main/java/yapp/allround3/project/controller/ProjectController.java
+++ b/src/main/java/yapp/allround3/project/controller/ProjectController.java
@@ -4,6 +4,7 @@ import org.springframework.web.bind.annotation.*;
 
 import lombok.RequiredArgsConstructor;
 import yapp.allround3.common.dto.CustomResponse;
+import yapp.allround3.common.security.SecurityUtils;
 import yapp.allround3.member.domain.Member;
 import yapp.allround3.participant.controller.dto.ParticipantDto;
 import yapp.allround3.project.controller.dto.ProjectResponse;
@@ -22,8 +23,8 @@ public class ProjectController {
 
     @ResponseBody
     @GetMapping("")
-    public CustomResponse<List<ProjectResponse>> findProjects(@RequestParam Long memberId) {
-        //TODO : 임시방편으로 memberId받도록 설정했음, 추후에 jwt 로직 추가되면 거기서 꺼내서 쓰도록 할 예정.
+    public CustomResponse<List<ProjectResponse>> findProjects(@RequestParam Long memberId){
+        // TODO : 임시방편으로 memberId받도록 설정했음, 추후에 jwt 로직 추가되면 거기서 꺼내서 쓰도록 할 예정.
         Member member = projectService.findMember(memberId);
         List<Project> projects = projectService.findProjectByMember(member);
         List<ProjectResponse> responses = projects.stream()
@@ -32,10 +33,24 @@ public class ProjectController {
                             .findParticipantsInProject(project).stream()
                             .map(ParticipantDto::of)
                             .toList();
-                    return ProjectResponse.of(project, participantDtos);
+                        return ProjectResponse.of(project, participantDtos);
                 }).toList();
 
         return CustomResponse.success(responses);
+    }
+
+    @ResponseBody
+    @GetMapping("")
+    public CustomResponse<ProjectResponse> findProjects(@PathVariable String projectId){
+        //Project id 암호화 String -> Id 변환이 여기서 일어나는게 맞는지 약간 의문임?
+        Project project = projectService.findProjectById(SecurityUtils.decodeKey(projectId));
+        List<ParticipantDto> participantDtos = projectService
+                .findParticipantsInProject(project).stream()
+                .map(ParticipantDto::of)
+                .toList();
+        ProjectResponse response = ProjectResponse.of(project, participantDtos);
+
+        return CustomResponse.success(response);
     }
 
 }

--- a/src/main/java/yapp/allround3/project/controller/ProjectController.java
+++ b/src/main/java/yapp/allround3/project/controller/ProjectController.java
@@ -23,14 +23,14 @@ public class ProjectController {
 
     @ResponseBody
     @GetMapping("")
-    public CustomResponse<List<ProjectResponse>> findProjects(@RequestParam Long memberId){
+    public CustomResponse<List<ProjectResponse>> findProjectsByMember(@RequestParam Long memberId){
         // TODO : 임시방편으로 memberId받도록 설정했음, 추후에 jwt 로직 추가되면 거기서 꺼내서 쓰도록 할 예정.
         Member member = projectService.findMember(memberId);
         List<Project> projects = projectService.findProjectByMember(member);
         List<ProjectResponse> responses = projects.stream()
                 .map(project -> {
                     List<ParticipantDto> participantDtos = projectService
-                            .findParticipantsInProject(project).stream()
+                            .findParticipantsByProject(project).stream()
                             .map(ParticipantDto::of)
                             .toList();
                         return ProjectResponse.of(project, participantDtos);
@@ -41,11 +41,11 @@ public class ProjectController {
 
     @ResponseBody
     @GetMapping("")
-    public CustomResponse<ProjectResponse> findProjects(@PathVariable String projectId){
+    public CustomResponse<ProjectResponse> findProjectById(@PathVariable String projectId){
         //Project id 암호화 String -> Id 변환이 여기서 일어나는게 맞는지 약간 의문임?
         Project project = projectService.findProjectById(SecurityUtils.decodeKey(projectId));
         List<ParticipantDto> participantDtos = projectService
-                .findParticipantsInProject(project).stream()
+                .findParticipantsByProject(project).stream()
                 .map(ParticipantDto::of)
                 .toList();
         ProjectResponse response = ProjectResponse.of(project, participantDtos);

--- a/src/main/java/yapp/allround3/project/controller/ProjectController.java
+++ b/src/main/java/yapp/allround3/project/controller/ProjectController.java
@@ -1,15 +1,41 @@
 package yapp.allround3.project.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import lombok.RequiredArgsConstructor;
+import yapp.allround3.common.dto.CustomResponse;
+import yapp.allround3.member.domain.Member;
+import yapp.allround3.participant.controller.dto.ParticipantDto;
+import yapp.allround3.project.controller.dto.ProjectResponse;
+import yapp.allround3.project.domain.Project;
 import yapp.allround3.project.service.ProjectService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/projects")
 @RequiredArgsConstructor
 public class ProjectController {
 
-	private final ProjectService projectService;
+    private final ProjectService projectService;
+
+
+    @ResponseBody
+    @GetMapping("")
+    public CustomResponse<List<ProjectResponse>> findProjects(@RequestParam Long memberId) {
+        //TODO : 임시방편으로 memberId받도록 설정했음, 추후에 jwt 로직 추가되면 거기서 꺼내서 쓰도록 할 예정.
+        Member member = projectService.findMember(memberId);
+        List<Project> projects = projectService.findProjectByMember(member);
+        List<ProjectResponse> responses = projects.stream()
+                .map(project -> {
+                    List<ParticipantDto> participantDtos = projectService
+                            .findParticipantsInProject(project).stream()
+                            .map(ParticipantDto::of)
+                            .toList();
+                    return ProjectResponse.of(project, participantDtos);
+                }).toList();
+
+        return CustomResponse.success(responses);
+    }
+
 }

--- a/src/main/java/yapp/allround3/project/controller/ProjectController.java
+++ b/src/main/java/yapp/allround3/project/controller/ProjectController.java
@@ -40,7 +40,7 @@ public class ProjectController {
     }
 
     @ResponseBody
-    @GetMapping("")
+    @GetMapping("/{projectId}")
     public CustomResponse<ProjectResponse> findProjectById(@PathVariable String projectId){
         //Project id 암호화 String -> Id 변환이 여기서 일어나는게 맞는지 약간 의문임?
         Project project = projectService.findProjectById(SecurityUtils.decodeKey(projectId));

--- a/src/main/java/yapp/allround3/project/controller/dto/ProjectResponse.java
+++ b/src/main/java/yapp/allround3/project/controller/dto/ProjectResponse.java
@@ -1,20 +1,56 @@
 package yapp.allround3.project.controller.dto;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import yapp.allround3.participant.controller.dto.ParticipantDto;
+import yapp.allround3.project.domain.Difficulty;
 import yapp.allround3.project.domain.Project;
 
 @Data
+@AllArgsConstructor
 public class ProjectResponse {
 
 	private String name;
 	private LocalDate startDate;
 	private LocalDate dueDate;
+	private Long dDay;
+	private String goal;
+	private Difficulty difficulty;
+	private Long progress;
+	private List<ParticipantDto> participantInfos;
 
-	public ProjectResponse(Project project) {
-		this.name = project.getName();
-		this.startDate = project.getStartDate();
-		this.dueDate = project.getDueDate();
+	public static ProjectResponse of(Project project, List<ParticipantDto> participantDtos) {
+
+		/*
+		TODO - 프로젝트 종료 여부도 status로 만들지 논의해야 할 것 같다. 아니면 Dday, 진행률 계산이 생각처럼 안나올 듯함.
+		EX) Project status=종료 라면 dday=0, 진행정도=100으로 세팅하도록 하는 로직 추가하면 될듯?
+		 */
+
+		return new ProjectResponse(
+				project.getName(),
+				project.getStartDate(),
+				project.getDueDate(),
+				calculateDuration(LocalDate.now(),project.getDueDate()),
+				project.getGoal(),
+				project.getDifficulty(),
+				calculateProgress(project.getStartDate(),project.getDueDate()),
+				participantDtos
+		);
 	}
+
+	public static Long calculateDuration(LocalDate start, LocalDate end){
+		return ChronoUnit.DAYS.between(start,end);
+	}
+
+	public static Long calculateProgress(LocalDate startDate, LocalDate endDate){
+		long projectDuration = calculateDuration(startDate,endDate);
+		long progressed = calculateDuration(startDate,LocalDate.now());
+		return (long)((float) progressed/projectDuration*100);
+	}
+
+
 }

--- a/src/main/java/yapp/allround3/project/controller/dto/ProjectResponse.java
+++ b/src/main/java/yapp/allround3/project/controller/dto/ProjectResponse.java
@@ -13,7 +13,7 @@ import yapp.allround3.project.domain.Project;
 @Data
 @AllArgsConstructor
 public class ProjectResponse {
-
+	private Long id;
 	private String name;
 	private LocalDate startDate;
 	private LocalDate dueDate;
@@ -31,6 +31,7 @@ public class ProjectResponse {
 		 */
 
 		return new ProjectResponse(
+				project.getId(),
 				project.getName(),
 				project.getStartDate(),
 				project.getDueDate(),

--- a/src/main/java/yapp/allround3/project/domain/Difficulty.java
+++ b/src/main/java/yapp/allround3/project/domain/Difficulty.java
@@ -1,0 +1,7 @@
+package yapp.allround3.project.domain;
+
+public enum Difficulty {
+    HARD,
+    MEDIUM,
+    EASY
+}

--- a/src/main/java/yapp/allround3/project/domain/Project.java
+++ b/src/main/java/yapp/allround3/project/domain/Project.java
@@ -29,12 +29,17 @@ public class Project extends BaseTimeEntity {
 
 	@Enumerated(value = EnumType.STRING)
 	private Difficulty difficulty;
+
+	@Enumerated(value = EnumType.STRING)
+	private ProjectStatus projectStatus;
+
 	@Builder
-	private Project(String name, LocalDate startDate, LocalDate dueDate,String goal, Difficulty difficulty) {
+	private Project(String name, LocalDate startDate, LocalDate dueDate,String goal, Difficulty difficulty,ProjectStatus projectStatus) {
 		this.name = name;
 		this.startDate = startDate;
 		this.dueDate = dueDate;
 		this.goal = goal;
 		this.difficulty = difficulty;
+		this.projectStatus= projectStatus;
 	}
 }

--- a/src/main/java/yapp/allround3/project/domain/Project.java
+++ b/src/main/java/yapp/allround3/project/domain/Project.java
@@ -2,10 +2,7 @@ package yapp.allround3.project.domain;
 
 import java.time.LocalDate;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,10 +25,16 @@ public class Project extends BaseTimeEntity {
 
 	private LocalDate dueDate;
 
+	private String goal;
+
+	@Enumerated(value = EnumType.STRING)
+	private Difficulty difficulty;
 	@Builder
-	private Project(String name, LocalDate startDate, LocalDate dueDate) {
+	private Project(String name, LocalDate startDate, LocalDate dueDate,String goal, Difficulty difficulty) {
 		this.name = name;
 		this.startDate = startDate;
 		this.dueDate = dueDate;
+		this.goal = goal;
+		this.difficulty = difficulty;
 	}
 }

--- a/src/main/java/yapp/allround3/project/domain/ProjectStatus.java
+++ b/src/main/java/yapp/allround3/project/domain/ProjectStatus.java
@@ -1,0 +1,9 @@
+package yapp.allround3.project.domain;
+
+public enum ProjectStatus {
+    NOTSTARTED,
+    INPROGRESS,
+    FEEDBACKREQUIRED,
+    FEEDBACKDONE,
+    COMPLETED
+}

--- a/src/main/java/yapp/allround3/project/repository/ProjectRepository.java
+++ b/src/main/java/yapp/allround3/project/repository/ProjectRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import yapp.allround3.project.domain.Project;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
-
 }

--- a/src/main/java/yapp/allround3/project/service/ProjectService.java
+++ b/src/main/java/yapp/allround3/project/service/ProjectService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import yapp.allround3.member.domain.Member;
+import yapp.allround3.member.repository.MemberRepository;
 import yapp.allround3.participant.domain.Participant;
 import yapp.allround3.participant.repository.ParticipantRepository;
 import yapp.allround3.project.domain.Project;
@@ -19,13 +20,22 @@ public class ProjectService {
 
 	private final ProjectRepository projectRepository;
 	private final ParticipantRepository participantRepository;
+	private final MemberRepository memberRepository;
 
 	@Transactional
 	public Project save(Project project) {
 		return projectRepository.save(project);
 	}
 
-	public List<Project> findByMember(Member member) {
+	public Member findMember(Long memberId){
+		return memberRepository.findMemberById(memberId);
+	}
+
+	public List<Participant> findParticipantsInProject(Project project){
+		return participantRepository.findParticipantsByProject(project);
+	}
+
+	public List<Project> findProjectByMember(Member member) {
 		List<Participant> participants = participantRepository.findByMember(member);
 
 		return participants.stream()

--- a/src/main/java/yapp/allround3/project/service/ProjectService.java
+++ b/src/main/java/yapp/allround3/project/service/ProjectService.java
@@ -1,13 +1,13 @@
 package yapp.allround3.project.service;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import yapp.allround3.common.exception.CustomException;
 import yapp.allround3.member.domain.Member;
 import yapp.allround3.member.repository.MemberRepository;
 import yapp.allround3.participant.domain.Participant;
@@ -47,6 +47,6 @@ public class ProjectService {
 
     public Project findProjectById(Long projectId) {
 		Optional<Project> project = projectRepository.findById(projectId);
-		return project.orElseThrow(NoSuchElementException::new);
+		return project.orElseThrow(()->new CustomException("존재하지 않는 프로젝트입니다."));
     }
 }

--- a/src/main/java/yapp/allround3/project/service/ProjectService.java
+++ b/src/main/java/yapp/allround3/project/service/ProjectService.java
@@ -33,7 +33,7 @@ public class ProjectService {
 		return memberRepository.findMemberById(memberId);
 	}
 
-	public List<Participant> findParticipantsInProject(Project project){
+	public List<Participant> findParticipantsByProject(Project project){
 		return participantRepository.findParticipantsByProject(project);
 	}
 

--- a/src/main/java/yapp/allround3/project/service/ProjectService.java
+++ b/src/main/java/yapp/allround3/project/service/ProjectService.java
@@ -1,6 +1,8 @@
 package yapp.allround3.project.service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,4 +44,9 @@ public class ProjectService {
 			.map(Participant::getProject)
 			.toList();
 	}
+
+    public Project findProjectById(Long projectId) {
+		Optional<Project> project = projectRepository.findById(projectId);
+		return project.orElseThrow(NoSuchElementException::new);
+    }
 }


### PR DESCRIPTION
## 주요 변경 사항
### 한 멤버가 갖고 있는 Project list 조회 기능 추가
- ProjectResponse Dto 수정, ParticipantDto 추가
- Project Entity 수정 (필드 추가)
- Project와 관련된 정보 조회 로직 구현
  - member->Participant->Project 조회
  - Project->Participant 조회
  - Project,Pariticipant 엔티티를 dto로 조립

### 현재 API 
![image](https://user-images.githubusercontent.com/65891711/206482272-4f36e04c-5541-484a-a67a-52d333e8d94e.png)


### 논의 사항
- REST API 스펙에 맞춰 개발하다보니 Project 엔티티 관련해서 추가된 필드(goal,difficulty)가 있어요. ERD에 반영을 하면 좋을 것 같아요!
- Project에 Project status를 추가할지 논의해 보면 좋을 것 같아요.
   - D-Day, 진행률 등을 계산할 때 오늘 날짜를 기준으로 계산을 하게 되는데요, 이 부분에서 종료일을 넘어가게 되면 D-Day가 (-)로 나오게 되고, 진행률 또한 100%를 넘어갈 수 있어요. 이 부분을 그대로 둘지, 아니면 종료 시 default 값을 설정할지에 대해 얘기하고 싶어요.
- Project 엔티티가 현재는 integer로 저장되어있는데, REST API 설계를 확인하면 id를 노출하지 않고 UUID로 조회하고 싶어하는 것 같아요. 그렇게 하려면 Project의 id를 UUID로 암호화하고, 우리가 UUID를 받았을 때 Project의 id로도 복호화 할 수 있어야 할 것 같은데, 이 부분에서 어떤 방식으로 암호화를 하면 좋을지 얘기해 보면 어떨까요? 
